### PR TITLE
update(cypress): increase default command timeout

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:5173",
     video: true,
+    defaultCommandTimeout: 10000,
     setupNodeEvents(on, config) {
       on(
         "after:spec",

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:5173",
     video: true,
-    defaultCommandTimeout: 10000,
+    defaultCommandTimeout: 15000,
     setupNodeEvents(on, config) {
       on(
         "after:spec",

--- a/cypress/e2e/PageObjects/PreLoading.ts
+++ b/cypress/e2e/PageObjects/PreLoading.ts
@@ -1,6 +1,6 @@
 class PreLoadingPage {
   get loadingHeader() {
-    return cy.get(".small", { timeout: 30000 });
+    return cy.get(".small");
   }
 
   get loadingMessage() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Update default command timeout to 15 seconds
- Removed custom timeout on preloading page, since this is not displayed now

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
