### PR TITLE
add(test): add tests and po for several settings pages

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     baseUrl: "http://localhost:5173",
     video: true,
     defaultCommandTimeout: 30000,
+    retries: { runMode: 0, openMode: 0 },
     setupNodeEvents(on, config) {
       on(
         "after:spec",

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
     baseUrl: "http://localhost:5173",
     video: true,
     defaultCommandTimeout: 30000,
-    retries: { runMode: 0, openMode: 0 },
     setupNodeEvents(on, config) {
       on(
         "after:spec",

--- a/cypress/e2e/PageObjects/AuthNewAccount.ts
+++ b/cypress/e2e/PageObjects/AuthNewAccount.ts
@@ -10,7 +10,7 @@ class AuthNewAccount {
   }
 
   get titleNewAccount() {
-    return cy.getByTestAttr("title-new-account", { timeout: 60000 });
+    return cy.getByTestAttr("title-new-account", { timeout: 120000 });
   }
 
   get textNewAccountSecondary() {

--- a/cypress/e2e/PageObjects/Settings/SettingsCustomizations.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsCustomizations.ts
@@ -1,0 +1,136 @@
+class SettingsCustomizations {
+  get appLanguageSection() {
+    return cy.getByTestAttr("section-app-language");
+  }
+
+  get appLanguageSectionLabel() {
+    return this.appLanguageSection.find("[data-cy='setting-section-label']");
+  }
+
+  get appLanguageSectionSelector() {
+    return cy.getByTestAttr("selector-app-language");
+  }
+
+  get appLanguageSectionSelectorOption() {
+    return this.appLanguageSectionSelector.find("[data-cy='select-option']");
+  }
+
+  get appLanguageSectionText() {
+    return this.appLanguageSection.find("[data-cy='setting-section-text']");
+  }
+
+  get customCSSSection() {
+    return cy.getByTestAttr("section-custom-css");
+  }
+
+  get customCSSSectionLabel() {
+    return this.customCSSSection.find("[data-cy='setting-section-label']");
+  }
+
+  get customCSSSectionText() {
+    return this.customCSSSection.find("[data-cy='setting-section-text']");
+  }
+
+  get customCSSSectionTextArea() {
+    return cy.getByTestAttr("text-area-custom-css");
+  }
+
+  get fontSection() {
+    return cy.getByTestAttr("section-font");
+  }
+
+  get fontSectionButton() {
+    return cy.getByTestAttr("button-font-open-folder");
+  }
+
+  get fontSectionLabel() {
+    return this.fontSection.find("[data-cy='setting-section-label']");
+  }
+
+  get fontSectionSelector() {
+    return cy.get("[data-cy^=selector-current-font-]");
+  }
+
+  get fontSectionSelectorOption() {
+    return this.fontSectionSelector.find("[data-cy='select-option']");
+  }
+
+  get fontSectionText() {
+    return this.fontSection.find("[data-cy='setting-section-text']");
+  }
+
+  get fontScalingSection() {
+    return cy.getByTestAttr("section-font-scaling");
+  }
+
+  get fontScalingSectionDecreaseButton() {
+    return cy.getByTestAttr("button-font-scaling-decrease");
+  }
+
+  get fontScalingSectionIncreaseButton() {
+    return cy.getByTestAttr("button-font-scaling-increase");
+  }
+
+  get fontScalingSectionInput() {
+    return cy.getByTestAttr("input-font-scaling");
+  }
+
+  get fontScalingSectionLabel() {
+    return this.fontScalingSection.find("[data-cy='setting-section-label']");
+  }
+
+  get fontScalingSectionText() {
+    return this.fontScalingSection.find("[data-cy='setting-section-text']");
+  }
+
+  get primaryColorSection() {
+    return cy.getByTestAttr("section-primary-color");
+  }
+
+  get primaryColorSectionColorSwatchButton() {
+    return this.primaryColorSection.find("[data-cy='color-swatch']");
+  }
+
+  get primaryColorSectionLabel() {
+    return this.primaryColorSection.find("[data-cy='setting-section-label']");
+  }
+
+  get primaryColorSectionPopUpButton() {
+    return cy.getByTestAttr("primary-colour-popup-button");
+  }
+
+  get primaryColorSectionText() {
+    return this.primaryColorSection.find("[data-cy='setting-section-text']");
+  }
+
+  get themeSection() {
+    return cy.getByTestAttr("section-theme");
+  }
+
+  get themeSectionOpenFolderButton() {
+    return cy.getByTestAttr("button-theme-open-folder");
+  }
+
+  get themeSectionThemeMoonButton() {
+    return cy.getByTestAttr("button-theme-moon");
+  }
+
+  get themeSectionLabel() {
+    return this.themeSection.find("[data-cy='setting-section-label']");
+  }
+
+  get themeSectionSelector() {
+    return cy.getByTestAttr("selector-theme");
+  }
+
+  get themeSectionSelectorOption() {
+    return this.themeSectionSelector.find("[data-cy='select-option']");
+  }
+
+  get themeSectionText() {
+    return this.themeSection.find("[data-cy='setting-section-text']");
+  }
+}
+
+export const settingsCustomizations: SettingsCustomizations =
+  new SettingsCustomizations();

--- a/cypress/e2e/PageObjects/Settings/SettingsCustomizations.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsCustomizations.ts
@@ -96,7 +96,7 @@ class SettingsCustomizations {
   }
 
   get primaryColorSectionPopUpButton() {
-    return cy.getByTestAttr("primary-colour-popup-button");
+    return cy.getByTestAttr("primary-color-popup-button");
   }
 
   get primaryColorSectionText() {

--- a/cypress/e2e/PageObjects/Settings/SettingsInventory.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsInventory.ts
@@ -1,0 +1,67 @@
+class SettingsInventory {
+  get buttonUnequipInventory() {
+    return cy.getByTestAttr("button-unequip-inventory");
+  }
+
+  get inventoryFrame() {
+    return cy.getByTestAttr("inventory-frame");
+  }
+
+  get inventoryFrameImage() {
+    return this.inventoryFrame.find("img");
+  }
+
+  get inventoryFrameButton() {
+    return this.inventoryFrame.find("[data-cy='inventory-item-button']");
+  }
+
+  get inventoryFrameName() {
+    return this.inventoryFrame.find("[data-cy='inventory-item-name']");
+  }
+
+  get inventoryFrameType() {
+    return this.inventoryFrame.find("[data-cy='inventory-item-type']");
+  }
+
+  get labelInventoryEquippedItems() {
+    return cy.getByTestAttr("label-inventory-equipped-items");
+  }
+
+  get labelInventoryFrame() {
+    return cy.getByTestAttr("label-inventory-frame");
+  }
+
+  get labelInventoryFrames() {
+    return cy.getByTestAttr("label-inventory-frames");
+  }
+
+  get labelProfileOverlays() {
+    return cy.getByTestAttr("label-profile-overlays");
+  }
+
+  get profilePictureFrame() {
+    return cy.getByTestAttr("inventory-profile-picture-frame");
+  }
+
+  get profilePictureFrameName() {
+    return this.profilePictureFrame.find("inventory-item-name");
+  }
+
+  get profilePictureFrameType() {
+    return this.profilePictureFrame.find("inventory-item-type");
+  }
+
+  get inventoryItemName() {
+    return cy.getByTestAttr("inventory-item-name");
+  }
+
+  get inventoryItemType() {
+    return cy.getByTestAttr("inventory-item-type");
+  }
+
+  public getFrameByName(name: string) {
+    return cy.getByTestAttr("inventory-item-name").contains(name).parent();
+  }
+}
+
+export const settingsInventory: SettingsInventory = new SettingsInventory();

--- a/cypress/e2e/PageObjects/Settings/SettingsMessages.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsMessages.ts
@@ -1,0 +1,57 @@
+class SettingsMessages {
+  get convertToEmojiSection() {
+    return cy.getByTestAttr("section-convert-to-emoji");
+  }
+
+  get convertToEmojiSectionCheckbox() {
+    return cy.getByTestAttr("checkbox-convert-to-emoji");
+  }
+
+  get convertToEmojiSectionLabel() {
+    return this.convertToEmojiSection.find("[data-cy='setting-section-label']");
+  }
+
+  get convertToEmojiSectionText() {
+    return this.convertToEmojiSection.find("[data-cy='setting-section-text']");
+  }
+
+  get markdownSupportSection() {
+    return cy.getByTestAttr("section-markdown-support");
+  }
+
+  get markdownSupportSectionCheckbox() {
+    return cy.getByTestAttr("checkbox-markdown-support");
+  }
+
+  get markdownSupportSectionLabel() {
+    return this.markdownSupportSection.find(
+      "[data-cy='setting-section-label']",
+    );
+  }
+
+  get markdownSupportSectionText() {
+    return this.markdownSupportSection.find("[data-cy='setting-section-text']");
+  }
+
+  get spamBotDetectionSection() {
+    return cy.getByTestAttr("section-spam-bot-detection");
+  }
+
+  get spamBotDetectionSectionCheckbox() {
+    return cy.getByTestAttr("checkbox-spam-bot-detection");
+  }
+
+  get spamBotDetectionSectionLabel() {
+    return this.spamBotDetectionSection.find(
+      "[data-cy='setting-section-label']",
+    );
+  }
+
+  get spamBotDetectionSectionText() {
+    return this.spamBotDetectionSection.find(
+      "[data-cy='setting-section-text']",
+    );
+  }
+}
+
+export const settingsMessages: SettingsMessages = new SettingsMessages();


### PR DESCRIPTION
### What this PR does 📖

- Adding Page Objects for Settings Inventory, Settings Customizations and Settings Messages pages with new UI locators for Uplink Web
- Write spec files with the cypress tests for the same pages

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
