### PR TITLE
update(refactor): use base classes for settings and main pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # Cypress Assets
+cypress/downloads/
 cypress/screenshots/
 cypress/videos/

--- a/cypress/e2e/01-pin-input.cy.ts
+++ b/cypress/e2e/01-pin-input.cy.ts
@@ -1,6 +1,6 @@
-import { authNewAccount } from "./PageObjects/AuthNewAccount";
-import { chatsMainPage } from "./PageObjects/ChatsMain";
-import { loginPinPage } from "./PageObjects/LoginPin";
+import authNewAccount from "./PageObjects/AuthNewAccount";
+import chatsMainPage from "./PageObjects/ChatsMain";
+import loginPinPage from "./PageObjects/LoginPin";
 import { faker } from "@faker-js/faker";
 
 describe("Create Account and Login Tests", () => {

--- a/cypress/e2e/02-friends.cy.ts
+++ b/cypress/e2e/02-friends.cy.ts
@@ -1,6 +1,6 @@
-import { authNewAccount } from "./PageObjects/AuthNewAccount";
-import { chatsMainPage } from "./PageObjects/ChatsMain";
-import { loginPinPage } from "./PageObjects/LoginPin";
+import authNewAccount from "./PageObjects/AuthNewAccount";
+import chatsMainPage from "./PageObjects/ChatsMain";
+import loginPinPage from "./PageObjects/LoginPin";
 
 describe("Friends Tests", () => {
   beforeEach(() => {

--- a/cypress/e2e/03-chats-sidebar.cy.ts
+++ b/cypress/e2e/03-chats-sidebar.cy.ts
@@ -1,6 +1,6 @@
-import { chatsMainPage } from "./PageObjects/ChatsMain";
-import { loginPinPage } from "./PageObjects/LoginPin";
-import { authNewAccount } from "./PageObjects/AuthNewAccount";
+import chatsMainPage from "./PageObjects/ChatsMain";
+import loginPinPage from "./PageObjects/LoginPin";
+import authNewAccount from "./PageObjects/AuthNewAccount";
 
 describe("Chats Sidebar Tests", () => {
   beforeEach(() => {

--- a/cypress/e2e/04-marketplace.cy.ts
+++ b/cypress/e2e/04-marketplace.cy.ts
@@ -1,6 +1,6 @@
-import { chatsMainPage } from "./PageObjects/ChatsMain";
-import { loginPinPage } from "./PageObjects/LoginPin";
-import { authNewAccount } from "./PageObjects/AuthNewAccount";
+import chatsMainPage from "./PageObjects/ChatsMain";
+import loginPinPage from "./PageObjects/LoginPin";
+import authNewAccount from "./PageObjects/AuthNewAccount";
 
 describe("Marketplace Tests", () => {
   beforeEach(() => {

--- a/cypress/e2e/05-settings-profile.cy.ts
+++ b/cypress/e2e/05-settings-profile.cy.ts
@@ -1,8 +1,8 @@
-import { chatsMainPage } from "./PageObjects/ChatsMain";
-import { loginPinPage } from "./PageObjects/LoginPin";
-import { authNewAccount } from "./PageObjects/AuthNewAccount";
-import { settingsProfile } from "./PageObjects/Settings/SettingsProfile";
-import { friendsPage } from "./PageObjects/Friends";
+import chatsMainPage from "./PageObjects/ChatsMain";
+import loginPinPage from "./PageObjects/LoginPin";
+import authNewAccount from "./PageObjects/AuthNewAccount";
+import settingsProfile from "./PageObjects/Settings/SettingsProfile";
+import friendsPage from "./PageObjects/Friends";
 
 describe("Settings Profile Tests", () => {
   beforeEach(() => {

--- a/cypress/e2e/06-settings-inventory.cy.ts
+++ b/cypress/e2e/06-settings-inventory.cy.ts
@@ -1,8 +1,8 @@
-import { authNewAccount } from "./PageObjects/AuthNewAccount";
-import { chatsMainPage } from "./PageObjects/ChatsMain";
-import { loginPinPage } from "./PageObjects/LoginPin";
-import { settingsInventory } from "./PageObjects/Settings/SettingsInventory";
-import { settingsProfile } from "./PageObjects/Settings/SettingsProfile";
+import authNewAccount from "./PageObjects/AuthNewAccount";
+import chatsMainPage from "./PageObjects/ChatsMain";
+import loginPinPage from "./PageObjects/LoginPin";
+import settingsInventory from "./PageObjects/Settings/SettingsInventory";
+import settingsProfile from "./PageObjects/Settings/SettingsProfile";
 
 describe("Settings - Inventory", () => {
   beforeEach(() => {
@@ -30,23 +30,14 @@ describe("Settings - Inventory", () => {
     cy.url().should("include", "/settings/inventory");
 
     // Fire inventory frame should not be equipped
-    settingsInventory
-      .getFrameByName("Fire")
-      .find("[data-cy='inventory-item-button']")
-      .find("p")
-      .should("have.text", "Equip");
+    settingsInventory.getFrameButtonText("Fire").should("have.text", "Equip");
 
     // Equip Fire inventory frame
-    settingsInventory
-      .getFrameByName("Fire")
-      .find("[data-cy='inventory-item-button']")
-      .click();
+    settingsInventory.clickOnFrameButton("Fire");
 
     // Fire inventory frame should be equipped
-    cy.getByTestAttr("inventory-item-name")
-      .contains("Fire")
-      .last()
-      .parent()
+    settingsInventory
+      .getFrameContainer("Fire")
       .should("have.class", "equipped");
 
     settingsInventory.profilePictureFrameName.should("have.text", "Fire");
@@ -54,43 +45,43 @@ describe("Settings - Inventory", () => {
       "have.text",
       "Profile Picture Frame",
     );
+
+    settingsInventory.buttonProfile.click();
+    settingsProfile.profileImageFrame
+      .should("exist")
+      .and("have.attr", "src", "/assets/frames/fire.png");
+
+    settingsProfile.buttonInventory.click();
+    ``;
+
     settingsInventory.profilePictureFrameUnequipButton
       .should("contain", "Unequip")
       .click();
 
     // Fire inventory frame should be equipped
-    cy.getByTestAttr("inventory-item-name")
-      .contains("Fire")
-      .last()
-      .parent()
+    settingsInventory
+      .getFrameContainer("Fire")
       .should("not.have.class", "equipped");
+
+    settingsInventory.buttonProfile.click();
+    settingsProfile.profileImageFrame.should("not.exist");
   });
 
   it("J3, J4, J5, J6 - Equipping and unequipping inventory item", () => {
     cy.url().should("include", "/settings/inventory");
 
     // Fire inventory frame should not be equipped
-    settingsInventory
-      .getFrameByName("Fire")
-      .find("[data-cy='inventory-item-button']")
-      .find("p")
-      .should("have.text", "Equip");
+    settingsInventory.getFrameButtonText("Fire").should("have.text", "Equip");
 
     // Equip Fire inventory frame
-    settingsInventory
-      .getFrameByName("Fire")
-      .find("[data-cy='inventory-item-button']")
-      .click();
+    settingsInventory.clickOnFrameButton("Fire");
 
     // Fire inventory frame should be equipped
-    cy.getByTestAttr("inventory-item-name")
-      .contains("Fire")
-      .last()
-      .parent()
+    settingsInventory
+      .getFrameContainer("Fire")
       .should("have.class", "equipped");
 
-    cy.get('[data-cy="inventory-frame"].equipped')
-      .find("[data-cy='inventory-item-button']")
+    settingsInventory.inventoryFrameEquippedButton
       .should("have.css", "background-color", "rgb(77, 77, 255)")
       .should("contain", "Equipped");
 
@@ -104,10 +95,8 @@ describe("Settings - Inventory", () => {
       .click();
 
     // Fire inventory frame should be equipped
-    cy.getByTestAttr("inventory-item-name")
-      .contains("Fire")
-      .last()
-      .parent()
+    settingsInventory
+      .getFrameContainer("Fire")
       .should("not.have.class", "equipped");
   });
 });

--- a/cypress/e2e/PageObjects/AuthNewAccount.ts
+++ b/cypress/e2e/PageObjects/AuthNewAccount.ts
@@ -1,6 +1,11 @@
 import { faker } from "@faker-js/faker";
+import MainPage from "./MainPage";
 
-class AuthNewAccount {
+class AuthNewAccount extends MainPage {
+  constructor() {
+    super();
+  }
+
   get buttonNewAccountGoBack() {
     return cy.getByTestAttr("button-new-account-go-back");
   }
@@ -60,4 +65,4 @@ class AuthNewAccount {
   }
 }
 
-export const authNewAccount: AuthNewAccount = new AuthNewAccount();
+export default new AuthNewAccount();

--- a/cypress/e2e/PageObjects/ChatsMain.ts
+++ b/cypress/e2e/PageObjects/ChatsMain.ts
@@ -1,4 +1,10 @@
-class ChatsMainPage {
+import MainPage from "./MainPage";
+
+class ChatsMainPage extends MainPage {
+  constructor() {
+    super();
+  }
+
   get addSomeone() {
     return cy.get(".add-someone", { timeout: 30000 });
   }
@@ -7,40 +13,12 @@ class ChatsMainPage {
     return cy.getByTestAttr("button-add-friends");
   }
 
-  get buttonChat() {
-    return cy.getByTestAttr("button-Chat");
-  }
-
   get buttonCreateGroupChat() {
     return cy.getByTestAttr("button-create-group-chat");
   }
 
-  get buttonFiles() {
-    return cy.getByTestAttr("button-Files");
-  }
-
-  get buttonFriends() {
-    return cy.getByTestAttr("button-Friends");
-  }
-
-  get buttonHideSidebar() {
-    return cy.getByTestAttr("button-hide-sidebar");
-  }
-
   get buttonMarketplace() {
     return cy.getByTestAttr("button-marketplace");
-  }
-
-  get buttonSettings() {
-    return cy.getByTestAttr("button-Settings");
-  }
-
-  get buttonShowSidebar() {
-    return cy.getByTestAttr("button-show-sidebar");
-  }
-
-  get buttonWallet() {
-    return cy.getByTestAttr("button-Wallet");
   }
 
   get createGroupButton() {
@@ -67,36 +45,8 @@ class ChatsMainPage {
     return cy.getByTestAttr("label-create-group-select-members");
   }
 
-  get inputSidebarSearch() {
-    return cy.getByTestAttr("input-sidebar-search");
-  }
-
-  get navigationBar() {
-    return cy.get(".navigation");
-  }
-
   get sectionAddSomeone() {
     return cy.getByTestAttr("section-add-someone");
-  }
-
-  get sidebar() {
-    return cy.getByTestAttr("sidebar");
-  }
-
-  get slimbar() {
-    return cy.getByTestAttr("slimbar");
-  }
-
-  get toastNotification() {
-    return cy.getByTestAttr("toast-notification");
-  }
-
-  get toastNotificationButton() {
-    return cy.getByTestAttr("toast-notification-button");
-  }
-
-  get toastNotificationText() {
-    return cy.getByTestAttr("toast-notification-text");
   }
 
   get topbar() {
@@ -107,25 +57,10 @@ class ChatsMainPage {
     this.topbar.click();
   }
 
-  public ensureSidebarIsDisplayed() {
-    this.navigationBar.then(($navBar) => {
-      if ($navBar.hasClass("vertical")) {
-        this.buttonShowSidebar.click();
-        this.sidebar.should("be.visible");
-      } else {
-        this.sidebar.should("be.visible");
-      }
-    });
-  }
-
-  public goToSettings() {
-    this.buttonSettings.click();
-  }
-
   public validateChatsMainPageIsShown() {
     this.addSomeone.should("exist");
     cy.location("href").should("include", "/chat");
   }
 }
 
-export const chatsMainPage: ChatsMainPage = new ChatsMainPage();
+export default new ChatsMainPage();

--- a/cypress/e2e/PageObjects/Friends.ts
+++ b/cypress/e2e/PageObjects/Friends.ts
@@ -1,4 +1,10 @@
-class FriendsPage {
+import MainPage from "./MainPage";
+
+class FriendsPage extends MainPage {
+  constructor() {
+    super();
+  }
+
   get buttonAddFriend() {
     return cy.getByTestAttr("button-add-friend");
   }
@@ -20,4 +26,4 @@ class FriendsPage {
   }
 }
 
-export const friendsPage: FriendsPage = new FriendsPage();
+export default new FriendsPage();

--- a/cypress/e2e/PageObjects/LoginPin.ts
+++ b/cypress/e2e/PageObjects/LoginPin.ts
@@ -1,4 +1,6 @@
-class LoginPinPage {
+import MainPage from "./MainPage";
+
+class LoginPinPage extends MainPage {
   get changeUserButton() {
     return cy.getByTestAttr("button-change-user");
   }
@@ -166,4 +168,4 @@ class LoginPinPage {
   }
 }
 
-export const loginPinPage: LoginPinPage = new LoginPinPage();
+export default new LoginPinPage();

--- a/cypress/e2e/PageObjects/MainPage.ts
+++ b/cypress/e2e/PageObjects/MainPage.ts
@@ -1,0 +1,74 @@
+export default class MainPage {
+  constructor() {}
+
+  get buttonChat() {
+    return cy.getByTestAttr("button-Chat");
+  }
+
+  get buttonFiles() {
+    return cy.getByTestAttr("button-Files");
+  }
+
+  get buttonFriends() {
+    return cy.getByTestAttr("button-Friends");
+  }
+
+  get buttonHideSidebar() {
+    return cy.getByTestAttr("button-hide-sidebar");
+  }
+
+  get buttonSettings() {
+    return cy.getByTestAttr("button-Settings");
+  }
+
+  get buttonShowSidebar() {
+    return cy.getByTestAttr("button-show-sidebar");
+  }
+
+  get buttonWallet() {
+    return cy.getByTestAttr("button-Wallet");
+  }
+
+  get inputSidebarSearch() {
+    return cy.getByTestAttr("input-sidebar-search");
+  }
+
+  get navigationBar() {
+    return cy.get(".navigation");
+  }
+
+  get sidebar() {
+    return cy.getByTestAttr("sidebar");
+  }
+
+  get slimbar() {
+    return cy.getByTestAttr("slimbar");
+  }
+
+  get toastNotification() {
+    return cy.getByTestAttr("toast-notification");
+  }
+
+  get toastNotificationButton() {
+    return cy.getByTestAttr("toast-notification-button");
+  }
+
+  get toastNotificationText() {
+    return cy.getByTestAttr("toast-notification-text");
+  }
+
+  public ensureSidebarIsDisplayed() {
+    this.navigationBar.then(($navBar) => {
+      if ($navBar.hasClass("vertical")) {
+        this.buttonShowSidebar.click();
+        this.sidebar.should("be.visible");
+      } else {
+        this.sidebar.should("be.visible");
+      }
+    });
+  }
+
+  public goToSettings() {
+    this.buttonSettings.click();
+  }
+}

--- a/cypress/e2e/PageObjects/PreLoading.ts
+++ b/cypress/e2e/PageObjects/PreLoading.ts
@@ -1,4 +1,10 @@
-class PreLoadingPage {
+import MainPage from "./MainPage";
+
+class PreLoadingPage extends MainPage {
+  constructor() {
+    super();
+  }
+
   get loadingHeader() {
     return cy.get(".small");
   }
@@ -24,4 +30,4 @@ class PreLoadingPage {
   }
 }
 
-export const preLoadingPage: PreLoadingPage = new PreLoadingPage();
+export default new PreLoadingPage();

--- a/cypress/e2e/PageObjects/Settings/SettingsBase.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsBase.ts
@@ -1,0 +1,47 @@
+export default class SettingsBase {
+  constructor() {}
+
+  get buttonAbout() {
+    return cy.getByTestAttr("button-About");
+  }
+
+  get buttonAccessibility() {
+    return cy.getByTestAttr("button-Accessibility");
+  }
+
+  get buttonAudioAndVideo() {
+    return cy.getByTestAttr("button-Audio & Video");
+  }
+
+  get buttonCustomization() {
+    return cy.getByTestAttr("button-Customization");
+  }
+
+  get buttonExtensions() {
+    return cy.getByTestAttr("button-Extensions");
+  }
+
+  get buttonInventory() {
+    return cy.getByTestAttr("button-Inventory");
+  }
+
+  get buttonKeybinds() {
+    return cy.getByTestAttr("button-Keybinds");
+  }
+
+  get buttonLicenses() {
+    return cy.getByTestAttr("button-Licenses");
+  }
+
+  get buttonMessages() {
+    return cy.getByTestAttr("button-Messages");
+  }
+
+  get buttonNotifications() {
+    return cy.getByTestAttr("button-Notifications");
+  }
+
+  get buttonProfile() {
+    return cy.getByTestAttr("button-Profile");
+  }
+}

--- a/cypress/e2e/PageObjects/Settings/SettingsCustomizations.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsCustomizations.ts
@@ -1,4 +1,10 @@
-class SettingsCustomizations {
+import SettingsBase from "./SettingsBase";
+
+class SettingsCustomizations extends SettingsBase {
+  constructor() {
+    super();
+  }
+
   get appLanguageSection() {
     return cy.getByTestAttr("section-app-language");
   }
@@ -132,5 +138,4 @@ class SettingsCustomizations {
   }
 }
 
-export const settingsCustomizations: SettingsCustomizations =
-  new SettingsCustomizations();
+export default new SettingsCustomizations();

--- a/cypress/e2e/PageObjects/Settings/SettingsInventory.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsInventory.ts
@@ -1,4 +1,10 @@
-class SettingsInventory {
+import SettingsBase from "./SettingsBase";
+
+class SettingsInventory extends SettingsBase {
+  constructor() {
+    super();
+  }
+
   get buttonUnequipInventory() {
     return cy.getByTestAttr("button-unequip-inventory");
   }
@@ -13,6 +19,12 @@ class SettingsInventory {
 
   get inventoryFrameButton() {
     return this.inventoryFrame.find("[data-cy='inventory-item-button']");
+  }
+
+  get inventoryFrameEquippedButton() {
+    return cy
+      .get('[data-cy="inventory-frame"].equipped')
+      .find("[data-cy='inventory-item-button']");
   }
 
   get inventoryFrameName() {
@@ -65,8 +77,28 @@ class SettingsInventory {
     return cy.getByTestAttr("inventory-item-type");
   }
 
-  public getFrameByName(name: string) {
+  public clickOnFrameButton(name: string) {
+    return this.getFrame(name)
+      .find("[data-cy='inventory-item-button']")
+      .click();
+  }
+
+  public getFrame(name: string) {
     return cy.getByTestAttr("inventory-item-name").contains(name).parent();
+  }
+
+  public getFrameButtonText(name: string) {
+    return this.getFrame(name)
+      .find("[data-cy='inventory-item-button']")
+      .find("p");
+  }
+
+  public getFrameContainer(name: string) {
+    return cy
+      .getByTestAttr("inventory-item-name")
+      .contains(name)
+      .last()
+      .parent();
   }
 
   public validateInventoryFrames(
@@ -86,4 +118,4 @@ class SettingsInventory {
   }
 }
 
-export const settingsInventory: SettingsInventory = new SettingsInventory();
+export default new SettingsInventory();

--- a/cypress/e2e/PageObjects/Settings/SettingsMessages.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsMessages.ts
@@ -1,4 +1,10 @@
-class SettingsMessages {
+import SettingsBase from "./SettingsBase";
+
+class SettingsMessages extends SettingsBase {
+  constructor() {
+    super();
+  }
+
   get convertToEmojiSection() {
     return cy.getByTestAttr("section-convert-to-emoji");
   }
@@ -54,4 +60,4 @@ class SettingsMessages {
   }
 }
 
-export const settingsMessages: SettingsMessages = new SettingsMessages();
+export default new SettingsMessages();

--- a/cypress/e2e/PageObjects/Settings/SettingsProfile.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsProfile.ts
@@ -1,49 +1,9 @@
-class SettingsProfile {
-  get buttonAbout() {
-    return cy.getByTestAttr("button-About");
-  }
+import SettingsBase from "./SettingsBase";
 
-  get buttonAccessibility() {
-    return cy.getByTestAttr("button-Accessibility");
+class SettingsProfile extends SettingsBase {
+  constructor() {
+    super();
   }
-
-  get buttonAudioAndVideo() {
-    return cy.getByTestAttr("button-Audio & Video");
-  }
-
-  get buttonCustomization() {
-    return cy.getByTestAttr("button-Customization");
-  }
-
-  get buttonExtensions() {
-    return cy.getByTestAttr("button-Extensions");
-  }
-
-  get buttonInventory() {
-    return cy.getByTestAttr("button-Inventory");
-  }
-
-  get buttonKeybinds() {
-    return cy.getByTestAttr("button-Keybinds");
-  }
-
-  get buttonLicenses() {
-    return cy.getByTestAttr("button-Licenses");
-  }
-
-  get buttonMessages() {
-    return cy.getByTestAttr("button-Messages");
-  }
-
-  get buttonNotifications() {
-    return cy.getByTestAttr("button-Notifications");
-  }
-
-  get buttonProfile() {
-    return cy.getByTestAttr("button-Profile");
-  }
-
-  // Getters from Settings Profile
 
   get inputSettingsProfileShortID() {
     return cy.getByTestAttr("input-settings-profile-short-id");
@@ -93,6 +53,10 @@ class SettingsProfile {
     return this.profilePictureUploadButton
       .parents(".profile-picture-container")
       .siblings("input");
+  }
+
+  get profileImageFrame() {
+    return cy.getByTestAttr("profile-image-frame");
   }
 
   get profilePicture() {
@@ -288,4 +252,4 @@ class SettingsProfile {
   }
 }
 
-export const settingsProfile: SettingsProfile = new SettingsProfile();
+export default new SettingsProfile();


### PR DESCRIPTION
### What this PR does 📖

- Refactored Page Objects to use base classes for Settings and Main, in order to have in base classes the UI elements that are repeated along several pages in the app
- Implemented refactored page objects across existing test specs
- Added validation to settings inventory test to ensure that profile frame is added/removed successfully from settings profile page
- Renamed settings inventory spec file for typo

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
