### PR TITLE
add(pageobjects): add page object ui element locators for settings

### DIFF
--- a/cypress/e2e/PageObjects/Settings/SettingsAbout.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsAbout.ts
@@ -1,0 +1,107 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsAbout extends SettingsBase {
+  constructor() {
+    super();
+  }
+
+  get aboutSection() {
+    return cy.getByTestAttr("section-about-header");
+  }
+
+  get aboutSectionLabel() {
+    return this.aboutSection.find("[data-cy='setting-section-label']");
+  }
+
+  get aboutSectionText() {
+    return this.aboutSection.find("[data-cy='setting-section-text']");
+  }
+
+  get devModeSection() {
+    return cy.getByTestAttr("section-about-dev-mode");
+  }
+
+  get devModeSectionButton() {
+    return cy.getByTestAttr("button-about-dev-mode");
+  }
+
+  get devModeSectionLabel() {
+    return this.openSourceCodeSection.find("[data-cy='setting-section-label']");
+  }
+
+  get devModeSectionText() {
+    return this.openSourceCodeSection.find("[data-cy='setting-section-text']");
+  }
+
+  get madeInSection() {
+    return cy.getByTestAttr("section-about-made-in");
+  }
+
+  get madeInSectionFlags() {
+    return cy.getByTestAttr("about-made-in-flags");
+  }
+
+  get madeInSectionLabel() {
+    return this.madeInSection.find("[data-cy='setting-section-label']");
+  }
+
+  get madeInSectionText() {
+    return this.madeInSection.find("[data-cy='setting-section-text']");
+  }
+
+  get openSourceCodeSection() {
+    return cy.getByTestAttr("section-about-open-source-code");
+  }
+
+  get openSourceCodeSectionButton() {
+    return cy.getByTestAttr("button-open-source-code");
+  }
+
+  get openSourceCodeSectionLabel() {
+    return this.openSourceCodeSection.find("[data-cy='setting-section-label']");
+  }
+
+  get openSourceCodeSectionText() {
+    return this.openSourceCodeSection.find("[data-cy='setting-section-text']");
+  }
+
+  get versionSection() {
+    return cy.getByTestAttr("section-about-version");
+  }
+
+  get versionSectionButton() {
+    return cy.getByTestAttr("button-check-for-update");
+  }
+
+  get versionSectionLabel() {
+    return this.versionSection.find("[data-cy='setting-section-label']");
+  }
+
+  get versionSectionText() {
+    return this.versionSection.find("[data-cy='setting-section-text']");
+  }
+
+  get websiteSection() {
+    return cy.getByTestAttr("section-about-website");
+  }
+
+  get websiteSectionButton() {
+    return cy.getByTestAttr("button-open-website");
+  }
+
+  get websiteSectionLabel() {
+    return this.versionSection.find("[data-cy='setting-section-label']");
+  }
+
+  get websiteSectionText() {
+    return this.versionSection.find("[data-cy='setting-section-text']");
+  }
+
+  public openDevMode() {
+    for (let i = 0; i < 10; i++) {
+      this.devModeSectionButton.click();
+    }
+  }
+}
+
+export default new SettingsAbout();

--- a/cypress/e2e/PageObjects/Settings/SettingsAccessibility.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsAccessibility.ts
@@ -1,0 +1,31 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsAccessibility extends SettingsBase {
+  constructor() {
+    super();
+  }
+
+  get openDyslexicSection() {
+    return cy.getByTestAttr("section-accessibility");
+  }
+
+  get openDyslexicSectionCheckbox() {
+    return cy.getByTestAttr("switch-accessibility-open-dyslexic");
+  }
+
+  get openDyslexicSectionLabel() {
+    return this.openDyslexicSection.find("[data-cy='setting-section-label']");
+  }
+
+  get openDyslexicSectionText() {
+    return this.openDyslexicSection.find("[data-cy='setting-section-text']");
+  }
+
+  get openDyslexicSectionSlider() {
+    return cy.get(
+      '[data-cy="section-accessibility"] > .body > .content > .switch > .slider',
+    );
+  }
+}
+
+export default new SettingsAccessibility();

--- a/cypress/e2e/PageObjects/Settings/SettingsAudio.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsAudio.ts
@@ -1,0 +1,9 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsAudio extends SettingsBase {
+  constructor() {
+    super();
+  }
+}
+
+export default new SettingsAudio();

--- a/cypress/e2e/PageObjects/Settings/SettingsDeveloper.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsDeveloper.ts
@@ -1,0 +1,9 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsDeveloper extends SettingsBase {
+  constructor() {
+    super();
+  }
+}
+
+export default new SettingsDeveloper();

--- a/cypress/e2e/PageObjects/Settings/SettingsExtensions.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsExtensions.ts
@@ -1,0 +1,9 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsExtensions extends SettingsBase {
+  constructor() {
+    super();
+  }
+}
+
+export default new SettingsExtensions();

--- a/cypress/e2e/PageObjects/Settings/SettingsKeybinds.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsKeybinds.ts
@@ -1,0 +1,9 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsKeybinds extends SettingsBase {
+  constructor() {
+    super();
+  }
+}
+
+export default new SettingsKeybinds();

--- a/cypress/e2e/PageObjects/Settings/SettingsLicenses.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsLicenses.ts
@@ -1,0 +1,9 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsLicenses extends SettingsBase {
+  constructor() {
+    super();
+  }
+}
+
+export default new SettingsLicenses();

--- a/cypress/e2e/PageObjects/Settings/SettingsNetwork.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsNetwork.ts
@@ -1,0 +1,9 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsNetwork extends SettingsBase {
+  constructor() {
+    super();
+  }
+}
+
+export default new SettingsNetwork();

--- a/cypress/e2e/PageObjects/Settings/SettingsNotifications.ts
+++ b/cypress/e2e/PageObjects/Settings/SettingsNotifications.ts
@@ -1,0 +1,97 @@
+import SettingsBase from "./SettingsBase";
+
+class SettingsNotifications extends SettingsBase {
+  constructor() {
+    super();
+  }
+
+  get enabledSection() {
+    return cy.getByTestAttr("section-notifications-enabled");
+  }
+
+  get enabledSectionCheckbox() {
+    return cy.getByTestAttr("switch-notifications-enabled");
+  }
+
+  get enabledSectionLabel() {
+    return this.enabledSection.find("[data-cy='setting-section-label']");
+  }
+
+  get enabledSectionText() {
+    return this.enabledSection.find("[data-cy='setting-section-text']");
+  }
+
+  get enabledSectionSlider() {
+    return cy.get(
+      '[data-cy="section-notifications-enabled"] > .body > .content > .switch > .slider',
+    );
+  }
+
+  get friendsSection() {
+    return cy.getByTestAttr("section-notifications-friends");
+  }
+
+  get friendsSectionCheckbox() {
+    return cy.getByTestAttr("switch-notifications-friends");
+  }
+
+  get friendsSectionLabel() {
+    return this.friendsSection.find("[data-cy='setting-section-label']");
+  }
+
+  get friendsSectionText() {
+    return this.friendsSection.find("[data-cy='setting-section-text']");
+  }
+
+  get friendsSectionSlider() {
+    return cy.get(
+      '[data-cy="section-notifications-friends"] > .body > .content > .switch > .slider',
+    );
+  }
+
+  get messagesSection() {
+    return cy.getByTestAttr("section-notifications-messages");
+  }
+
+  get messagesSectionCheckbox() {
+    return cy.getByTestAttr("switch-notifications-messages");
+  }
+
+  get messagesSectionLabel() {
+    return this.messagesSection.find("[data-cy='setting-section-label']");
+  }
+
+  get messagesSectionText() {
+    return this.messagesSection.find("[data-cy='setting-section-text']");
+  }
+
+  get messagesSectionSlider() {
+    return cy.get(
+      '[data-cy="section-notifications-messages"] > .body > .content > .switch > .slider',
+    );
+  }
+
+  get settingsSection() {
+    return cy.getByTestAttr("section-notifications-settings");
+  }
+
+  get settingsSectionCheckbox() {
+    return cy.getByTestAttr("switch-notifications-settings");
+  }
+
+  get settingsSectionLabel() {
+    return this.settingsSection.find("[data-cy='setting-section-label']");
+  }
+
+  get settingsSectionText() {
+    return this.settingsSection.find("[data-cy='setting-section-text']");
+  }
+
+  get settingsSectionSlider() {
+    return cy.get(
+      '[data-cy="section-notifications-settings"] > .body > .content > .switch > .slider',
+    );
+  }
+}
+
+export default new SettingsNotifications();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -5,6 +5,13 @@ declare namespace Cypress {
       ...options: any
     ): Chainable<JQuery<HTMLElement>>;
     paste(subject: any, text: string): Chainable<JQuery<HTMLElement>>;
+    getClipboardTextAndTriggerContextMenu(): void;
+    getClipboardTextAndTriggerCopy(): void;
+    assertText(
+      element: Chainable<JQuery<HTMLElement>>,
+      text: string,
+      message: string,
+    ): Chainable<JQuery<HTMLElement>>;
   }
 }
 
@@ -21,45 +28,50 @@ Cypress.Commands.add("paste", { prevSubject: true }, (subject, text) => {
   return subject;
 });
 
-let last8Chars; // Declare the variable outside the tests to make it accessible
-
 // Command to trigger the context menu when doing right-click on the username
-Cypress.Commands.add('getClipboardTextAndTriggerContextMenu', () => {
+Cypress.Commands.add("getClipboardTextAndTriggerContextMenu", () => {
   return cy.window().then((win) => {
     return win.navigator.clipboard.readText().then((clipboardText) => {
-      cy.wrap(clipboardText).as('clipboardText'); // Save clipboard text as an alias
-      return cy.get('[data-cy="input-settings-profile-short-id"]').then(($input) => {
-        const element = $input[0];
-        element.dispatchEvent(
-          new MouseEvent('contextmenu', {
-            bubbles: true,
-            cancelable: false,
-            view: window,
-            button: 2,
-          })
-        );
-      });
+      cy.wrap(clipboardText).as("clipboardText"); // Save clipboard text as an alias
+      return cy
+        .get('[data-cy="input-settings-profile-short-id"]')
+        .then(($input) => {
+          const element = $input[0];
+          element.dispatchEvent(
+            new MouseEvent("contextmenu", {
+              bubbles: true,
+              cancelable: false,
+              view: window,
+              button: 2,
+            }),
+          );
+        });
     });
   });
 });
 
 // Command to trigger the copy when clicking on the username
-Cypress.Commands.add('getClipboardTextAndTriggerCopy', () => {
-  return cy.get('[data-cy="input-settings-profile-short-id"]').then(($input) => {
-    const element = $input[0];
-    element.select(); // Select the input element
-    document.execCommand('copy'); // Copy the selected text
-    return cy.window().then((win) => {
-      return win.navigator.clipboard.readText().then((clipboardText) => {
-        cy.wrap(clipboardText).as('clipboardText'); // Save clipboard text as an alias
+Cypress.Commands.add("getClipboardTextAndTriggerCopy", () => {
+  return cy
+    .get('[data-cy="input-settings-profile-short-id"]')
+    .then(($input) => {
+      const element: any = $input[0];
+      element.select(); // Select the input element
+      document.execCommand("copy"); // Copy the selected text
+      return cy.window().then((win) => {
+        return win.navigator.clipboard.readText().then((clipboardText) => {
+          cy.wrap(clipboardText).as("clipboardText"); // Save clipboard text as an alias
+        });
       });
     });
-  });
 });
 
 // Command to assert text
-Cypress.Commands.add('assertText', (element, text, message) => {
-  element.should("have.text", text, { log: false }).then(($el) => {
-    expect($el.text()).to.eq(text, message);
-  });
-});
+Cypress.Commands.add(
+  "assertText",
+  (element: any, text: string, message: string) => {
+    element.should("have.text", text, { log: false }).then(($el) => {
+      expect($el.text()).to.eq(text, message);
+    });
+  },
+);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Add page object files for remaining Settings pages
- Fully created for About, Accessiblity and Notifications. For others its just the file with class declaration. These will be updated next with ui locators
- Also, added types and fixed lint errors on cypress commands. Removed one unused variable

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
