### PR TITLE
add(test): add tests for account creation - more

### DIFF
--- a/playwright/PageObjects/AuthNewAccount.ts
+++ b/playwright/PageObjects/AuthNewAccount.ts
@@ -3,38 +3,47 @@ import { expect, type Locator, type Page } from "@playwright/test";
 
 export class AuthNewAccount extends MainPage {
   readonly page: Page;
-  readonly buttonNewAccountGoBack: Locator;
   readonly buttonNewAccountCreate: Locator;
-  readonly titleNewAccount: Locator;
-  readonly textNewAccountSecondary: Locator;
-  readonly profilePictureNewAccount: Locator;
-  readonly labelNewAccountUsername: Locator;
+  readonly buttonNewAccountFileUpload: Locator;
+  readonly buttonNewAccountGoBack: Locator;
+  readonly identiconNewAccount: Locator;
+  readonly inputNewAccountFileUpload: Locator;
+  readonly inputNewAccountStatus: Locator;
   readonly inputNewAccountUsername: Locator;
   readonly labelNewAccountStatus: Locator;
-  readonly inputNewAccountStatus: Locator;
+  readonly labelNewAccountUsername: Locator;
+  readonly profileImageNewAccount: Locator;
+  readonly profilePictureNewAccount: Locator;
+  readonly textNewAccountSecondary: Locator;
+  readonly titleNewAccount: Locator;
 
   constructor(page: Page) {
     super(page);
     this.page = page;
+
+    this.buttonNewAccountCreate = page.getByTestId("button-new-account-create");
+    this.buttonNewAccountFileUpload = page.getByTestId("button-file-upload");
     this.buttonNewAccountGoBack = page.getByTestId(
       "button-new-account-go-back",
     );
-    this.buttonNewAccountCreate = page.getByTestId("button-new-account-create");
-    this.titleNewAccount = page.getByTestId("title-new-account");
-    this.textNewAccountSecondary = page.getByTestId(
-      "text-new-account-secondary",
-    );
-    this.profilePictureNewAccount = page.getByTestId(
-      "profile-picture-new-account",
+    this.identiconNewAccount = page.locator(".identicon").locator("img");
+    this.inputNewAccountFileUpload = page.locator("input[type=file]");
+    this.inputNewAccountStatus = page.getByTestId("input-new-account-status");
+    this.inputNewAccountUsername = page.getByTestId(
+      "input-new-account-username",
     );
     this.labelNewAccountUsername = page.getByTestId(
       "label-new-account-username",
     );
-    this.inputNewAccountUsername = page.getByTestId(
-      "input-new-account-username",
-    );
     this.labelNewAccountStatus = page.getByTestId("label-new-account-status");
-    this.inputNewAccountStatus = page.getByTestId("input-new-account-status");
+    this.profileImageNewAccount = page.getByTestId("profile-image");
+    this.profilePictureNewAccount = page.getByTestId(
+      "profile-picture-new-account",
+    );
+    this.titleNewAccount = page.getByTestId("title-new-account");
+    this.textNewAccountSecondary = page.getByTestId(
+      "text-new-account-secondary",
+    );
   }
 
   async clickOnCreateAccount() {
@@ -46,6 +55,11 @@ export class AuthNewAccount extends MainPage {
     this.typeOnUsername(username);
     this.typeOnStatus(status);
     this.buttonNewAccountCreate.click();
+  }
+
+  async uploadProfilePicture(file: string) {
+    await this.buttonNewAccountFileUpload.click();
+    await this.inputNewAccountFileUpload.setInputFiles(file);
   }
 
   async typeOnStatus(status: string) {

--- a/playwright/PageObjects/Settings/SettingsProfile.ts
+++ b/playwright/PageObjects/Settings/SettingsProfile.ts
@@ -17,9 +17,9 @@ export class SettingsProfile extends SettingsBase {
   readonly accountIntegrationsItemPlatformInput: Locator;
   readonly accountIntegrationsLabel: Locator;
   readonly accountIntegrationsNewAddButton: Locator;
-  readonly accountIntegrationsNewCancelButton: Locator;
   readonly accountIntegrationsNewAddressInput: Locator;
   readonly accountIntegrationsNewAddressLabel: Locator;
+  readonly accountIntegrationsNewCancelButton: Locator;
   readonly accountIntegrationsNewGenericInput: Locator;
   readonly accountIntegrationsNewLogo: Locator;
   readonly accountIntegrationsNewPlatformLabel: Locator;
@@ -34,6 +34,7 @@ export class SettingsProfile extends SettingsBase {
   readonly contextMenuOptionCopyID: Locator;
   readonly contextMenuOptionDeleteBannerPicture: Locator;
   readonly contextMenuOptionDeleteProfilePicture: Locator;
+  readonly identiconSettingsProfile: Locator;
   readonly inputSettingsProfileShortID: Locator;
   readonly inputSettingsProfileShortIDGroup: Locator;
   readonly inputSettingsProfileStatus: Locator;
@@ -44,9 +45,18 @@ export class SettingsProfile extends SettingsBase {
   readonly logOutSectionButton: Locator;
   readonly logOutSectionLabel: Locator;
   readonly logOutSectionText: Locator;
+  readonly onlineStatusSection: Locator;
+  readonly onlineStatusSectionLabel: Locator;
+  readonly onlineStatusSectionSelectorCurrentlyDoNotDisturb: Locator;
+  readonly onlineStatusSectionSelectorCurrentlyIdle: Locator;
+  readonly onlineStatusSectionSelectorCurrentlyOffline: Locator;
+  readonly onlineStatusSectionSelectorCurrentlyOnline: Locator;
+  readonly onlineStatusSectionSelectOptions: Locator;
+  readonly onlineStatusSectionText: Locator;
   readonly profileBanner: Locator;
   readonly profileBannerContainer: Locator;
   readonly profileBannerInput: Locator;
+  readonly profileImage: Locator;
   readonly profileImageFrame: Locator;
   readonly profilePicture: Locator;
   readonly profilePictureContainer: Locator;
@@ -64,14 +74,6 @@ export class SettingsProfile extends SettingsBase {
   readonly saveControls: Locator;
   readonly saveControlsButtonCancel: Locator;
   readonly saveControlsButtonSave: Locator;
-  readonly onlineStatusSection: Locator;
-  readonly onlineStatusSectionLabel: Locator;
-  readonly onlineStatusSectionSelectorCurrentlyDoNotDisturb: Locator;
-  readonly onlineStatusSectionSelectorCurrentlyIdle: Locator;
-  readonly onlineStatusSectionSelectorCurrentlyOffline: Locator;
-  readonly onlineStatusSectionSelectorCurrentlyOnline: Locator;
-  readonly onlineStatusSectionSelectOptions: Locator;
-  readonly onlineStatusSectionText: Locator;
   readonly storeRecoverySeedSection: Locator;
   readonly storeRecoverySeedCheckbox: Locator;
   readonly storeRecoverySeedText: Locator;
@@ -173,6 +175,7 @@ export class SettingsProfile extends SettingsBase {
     this.contextMenuOptionDeleteProfilePicture = page.getByTestId(
       "context-menu-option-Delete Profile Picture",
     );
+    this.identiconSettingsProfile = page.locator(".identicon").locator("img");
     this.inputSettingsProfileShortID = page.getByTestId(
       "input-settings-profile-short-id",
     );
@@ -199,9 +202,29 @@ export class SettingsProfile extends SettingsBase {
     this.logOutSectionText = this.logOutSection.getByTestId(
       "setting-section-text",
     );
+    this.onlineStatusSection = page.getByTestId("section-online-status");
+    this.onlineStatusSectionLabel = this.onlineStatusSection.getByTestId(
+      "setting-section-label",
+    );
+    this.onlineStatusSectionSelectorCurrentlyDoNotDisturb =
+      this.onlineStatusSection.getByTestId(
+        "selector-current-status-do-not-disturb",
+      );
+    this.onlineStatusSectionSelectorCurrentlyIdle =
+      this.onlineStatusSection.getByTestId("selector-current-status-idle");
+    this.onlineStatusSectionSelectorCurrentlyOffline =
+      this.onlineStatusSection.getByTestId("selector-current-status-offline");
+    this.onlineStatusSectionSelectorCurrentlyOnline =
+      this.onlineStatusSection.getByTestId("selector-current-status-online");
+    this.onlineStatusSectionSelectOptions =
+      this.onlineStatusSection.getByTestId("select-options");
+    this.onlineStatusSectionText = this.onlineStatusSection.getByTestId(
+      "setting-section-text",
+    );
     this.profileBanner = page.getByTestId("profile-banner");
     this.profileBannerContainer = page.locator(".profile-header");
     this.profileBannerInput = this.profileBannerContainer.locator("input");
+    this.profileImage = page.getByTestId("profile-image");
     this.profileImageFrame = page.getByTestId("profile-image-frame");
     this.profilePicture = page.getByTestId("profile-picture");
     this.profilePictureContainer = page.locator(".profile-picture-container");
@@ -231,25 +254,7 @@ export class SettingsProfile extends SettingsBase {
     this.saveControlsButtonCancel =
       this.saveControls.getByTestId("button-cancel");
     this.saveControlsButtonSave = this.saveControls.getByTestId("button-save");
-    this.onlineStatusSection = page.getByTestId("section-online-status");
-    this.onlineStatusSectionLabel = this.onlineStatusSection.getByTestId(
-      "setting-section-label",
-    );
-    this.onlineStatusSectionSelectorCurrentlyDoNotDisturb =
-      this.onlineStatusSection.getByTestId(
-        "selector-current-status-do-not-disturb",
-      );
-    this.onlineStatusSectionSelectorCurrentlyIdle =
-      this.onlineStatusSection.getByTestId("selector-current-status-idle");
-    this.onlineStatusSectionSelectorCurrentlyOffline =
-      this.onlineStatusSection.getByTestId("selector-current-status-offline");
-    this.onlineStatusSectionSelectorCurrentlyOnline =
-      this.onlineStatusSection.getByTestId("selector-current-status-online");
-    this.onlineStatusSectionSelectOptions =
-      this.onlineStatusSection.getByTestId("select-options");
-    this.onlineStatusSectionText = this.onlineStatusSection.getByTestId(
-      "setting-section-text",
-    );
+
     this.storeRecoverySeedSection = page.getByTestId(
       "section-store-recovery-seed",
     );

--- a/playwright/specs/07-settings-profile.spec.ts
+++ b/playwright/specs/07-settings-profile.spec.ts
@@ -71,7 +71,7 @@ test.describe("Settings Profile Tests", () => {
     );
   });
 
-  test.skip("I5 - Profile picture appears blank until custom profile picture is set", async ({
+  test.skip("I5 - Profile picture shows default profile picture until custom profile picture is set", async ({
     settingsProfile,
   }) => {
     // Upload Profile Picture
@@ -431,11 +431,22 @@ test.describe("Settings Profile Tests", () => {
     await settingsProfile.validateRecoveryPhraseIsHidden();
   });
 
+  test.skip(
+    "I22 - Clicking copy should copy the Recovery Phrase to the users clipboard",
+    {
+      annotation: {
+        type: "issue",
+        description: "https://github.com/Satellite-im/UplinkWeb/issues/378",
+      },
+    },
+    async ({ settingsProfile }) => {
+      await settingsProfile.revealPhraseSectionButtonCopyPhrase.click();
+    },
+  );
+
   // Cannot be automated for now since copy button does not perform any action
   /*
-  test.skip("I22 - Clicking copy should copy the Recovery Phrase to the users clipboard", async ({
-    page,
-  }) => {});
+  
 
   // Cannot be automated for now since checkbox checked or not checked works on the same way for now
   test.skip("I23 - User should be able to click checkbox to determine whether they want to store Recovery Phrase on account", async ({


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Updated main account creation test to assert texts displayed on screens displayed when creating a fresh account
- Adding automated test to upload profile picture during account creation and making sure this one is preserved and displayed on Settings Profile page
- Adding automated test to validate that by default identicon image is assigned to user and making sure this identicon image is preserved and displayed on Settings Profile page

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
