### PR TITLE
add(test): add tests for seed phrases

### DIFF
--- a/playwright/PageObjects/SaveRecoverySeed.ts
+++ b/playwright/PageObjects/SaveRecoverySeed.ts
@@ -1,5 +1,6 @@
 import MainPage from "./MainPage";
 import { expect, type Locator, type Page } from "@playwright/test";
+import { readFile } from "fs/promises";
 
 export class SaveRecoverySeedPage extends MainPage {
   readonly buttonDownloadPhrase: Locator;
@@ -26,19 +27,27 @@ export class SaveRecoverySeedPage extends MainPage {
 
   async getRecoveryPhrase() {
     let phrase = [];
+
+    // Loop through each of the 12 phrases
     for (let i = 1; i <= 12; i++) {
-      await expect(
-        this.page.getByTestId(`ordered-phrase-number-${i}`),
-      ).toBeVisible();
-      await expect(
-        this.page.getByTestId(`ordered-phrase-word-${i}`),
-      ).toBeVisible();
+      // Ensure the phrase number element exists
+      await this.page
+        .locator(`[data-cy="ordered-phrase-number-${i}"]`)
+        .waitFor({ state: "attached" });
+
+      // Ensure the phrase word element exists
+      await this.page
+        .locator(`[data-cy="ordered-phrase-word-${i}"]`)
+        .waitFor({ state: "attached" });
+
+      // Get the text from the <p> tag inside the phrase word element
       const text = await this.page
-        .getByTestId(`ordered-phrase-word-${i}`)
+        .locator(`[data-cy="ordered-phrase-word-${i}"]`)
         .locator("p")
-        .getAttribute("innerText");
+        .innerText();
       phrase.push(text);
     }
+
     return phrase;
   }
 
@@ -47,5 +56,28 @@ export class SaveRecoverySeedPage extends MainPage {
       .locator(`[data-cy^="ordered-phrase-word-`)
       .count();
     return count;
+  }
+
+  async readRecoveryPhraseFile(filePath: string) {
+    const fileContent = await readFile(filePath, "utf-8");
+    const fileSeedPhraseArray = fileContent.split(/\s+/).filter(Boolean);
+    console.log("Raw File Content:", fileContent);
+    return fileSeedPhraseArray;
+  }
+
+  async saveRecoverySeed() {
+    // Wait for the download event
+    const filename = "seed-phrase.txt";
+    const downloadPromise = this.page.waitForEvent("download");
+    await this.buttonDownloadPhrase.click();
+    const download = await downloadPromise;
+
+    // Save the file manually to the specified folder
+    const savedFilePath = "./downloads/" + filename;
+
+    await download.saveAs(savedFilePath); // Save the file to the desired folder
+
+    // Return the saved file path for further validation
+    return savedFilePath;
   }
 }

--- a/playwright/PageObjects/SaveRecoverySeed.ts
+++ b/playwright/PageObjects/SaveRecoverySeed.ts
@@ -61,7 +61,6 @@ export class SaveRecoverySeedPage extends MainPage {
   async readRecoveryPhraseFile(filePath: string) {
     const fileContent = await readFile(filePath, "utf-8");
     const fileSeedPhraseArray = fileContent.split(/\s+/).filter(Boolean);
-    console.log("Raw File Content:", fileContent);
     return fileSeedPhraseArray;
   }
 

--- a/playwright/specs/01-pin-input.spec.ts
+++ b/playwright/specs/01-pin-input.spec.ts
@@ -453,4 +453,79 @@ test.describe("Create Account and Login Tests", () => {
     await page.waitForURL("/settings/profile");
     await expect(settingsProfile.identiconSettingsProfile).toBeVisible();
   });
+
+  test("Download seed phrase file", async ({ enterPinUserContext }) => {
+    const page = enterPinUserContext.page;
+    const viewport = enterPinUserContext.viewport;
+    const chatsMainPage = new ChatsMainPage(page, viewport);
+    const createOrImport = new CreateOrImportPage(page, viewport);
+    const authNewAccount = new AuthNewAccount(page, viewport);
+    const loginPinPage = new LoginPinPage(page, viewport);
+    const saveRecoverySeed = new SaveRecoverySeedPage(page, viewport);
+    const settingsProfile = new SettingsProfile(page, viewport);
+    let recoverySeedFile: string[];
+
+    await test.step("Start account creation until Save Recovery Seed Page", async () => {
+      // Click on Create New Account
+      await createOrImport.clickCreateNewAccount();
+
+      // Enter Username and Status
+      await authNewAccount.validateLoadingHeader();
+      await authNewAccount.typeOnUsername(username);
+      await authNewAccount.typeOnStatus(status);
+
+      // Validate identicon image is assigned to user
+      await expect(authNewAccount.identiconNewAccount).toBeVisible();
+      await authNewAccount.buttonNewAccountCreate.click();
+
+      // Login Page Test
+      await loginPinPage.waitUntilPageIsLoaded();
+      await loginPinPage.goToPinSettings();
+      await loginPinPage.clickStayUnlockedSwitch();
+      await loginPinPage.enterPin(pinNumber);
+      await loginPinPage.pinButtonConfirm.click();
+    });
+
+    await test.step("Save Recovery Phrase displayed into a file", async () => {
+      // Download Recovery Seed Phrase
+      await saveRecoverySeed.saveRecoverySeed();
+    });
+
+    await test.step("Compare output from file vs phrase displayed", async () => {
+      // Compare recovery seed phrase displayed vs downloaded
+      recoverySeedFile = await saveRecoverySeed.readRecoveryPhraseFile(
+        "./downloads/seed-phrase.txt",
+      );
+      const recoverySeedDisplayed = await saveRecoverySeed.getRecoveryPhrase();
+      console.log("Displayed Phrase:", recoverySeedDisplayed);
+      expect(recoverySeedFile).toEqual(recoverySeedDisplayed);
+    });
+
+    await test.step("Finish account creation and go to Settings Profile", async () => {
+      // Click on I Saved It
+      await saveRecoverySeed.clickOnSavedIt();
+
+      // Once that user is in Chats page, go to Settings Profile
+      await page.waitForURL("/chat");
+      await chatsMainPage.goToSettings();
+      await page.waitForURL("/settings/profile");
+
+      // Hide sidebar if viewport is Mobile Chrome
+      if (viewport === "mobile-chrome") {
+        await chatsMainPage.buttonHideSidebar.click();
+      }
+    });
+
+    await test.step("In Settings Profile, show Recovery Seed Phrase", async () => {
+      // Show Recovery Phrase and ensure phrase displayed matches with phrase shown during account creation
+      await settingsProfile.revealPhraseSectionRevealButton.click();
+      await settingsProfile.validateRecoveryPhraseIsShown();
+      await settingsProfile.revealPhraseSectionButtonCopyPhrase.click();
+    });
+
+    await test.step("Compare Recovery Seed Phrase displayed vs downloaded", async () => {
+      const settingProfilePhrase = await settingsProfile.getRecoveryPhrase();
+      expect(recoverySeedFile).toEqual(settingProfilePhrase);
+    });
+  });
 });

--- a/playwright/specs/01-pin-input.spec.ts
+++ b/playwright/specs/01-pin-input.spec.ts
@@ -497,7 +497,6 @@ test.describe("Create Account and Login Tests", () => {
         "./downloads/seed-phrase.txt",
       );
       const recoverySeedDisplayed = await saveRecoverySeed.getRecoveryPhrase();
-      console.log("Displayed Phrase:", recoverySeedDisplayed);
       expect(recoverySeedFile).toEqual(recoverySeedDisplayed);
     });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Add test for saving seed phrase during account creation
- Add test for seed phrase displayed during account creation matches vs phrase downloaded
- Add test for seed phrase displayed on settings profile matches vs phrase downloaded/displayed during account creation

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
