### PR TITLE
update(test): validate only a portion of image src

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/UplinkWeb
+          ref: Bug/SAT-854/call-video-popout-not-showing
 
       - name: Checkout Automated Tests directory 🔖
         uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/UplinkWeb
-          ref: Bug/SAT-854/call-video-popout-not-showing
 
       - name: Checkout Automated Tests directory 🔖
         uses: actions/checkout@v4

--- a/playwright/PageObjects/CallElements/CallScreen.ts
+++ b/playwright/PageObjects/CallElements/CallScreen.ts
@@ -243,15 +243,19 @@ export class CallScreen extends MainPage {
     remoteUserImgSrc: string,
   ) {
     // Validate local user contents
-    await expect(this.participantProfilePictureImage.first()).toHaveAttribute(
-      "src",
-      localUserImgSrc,
+    const localUserImage = await this.participantProfilePictureImage
+      .first()
+      .getAttribute("src");
+    expect(localUserImage.substring(0, 100)).toBe(
+      localUserImgSrc.substring(0, 100),
     );
 
     // Validate remote user profile picture
-    await expect(this.participantProfilePictureImage.last()).toHaveAttribute(
-      "src",
-      remoteUserImgSrc,
+    const remoteUserImage = await this.participantProfilePictureImage
+      .last()
+      .getAttribute("src");
+    expect(remoteUserImage.substring(0, 100)).toBe(
+      remoteUserImgSrc.substring(0, 100),
     );
 
     // Validate number of users in call displayed in label


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Updating validation of profile picture sources on videocall modal to just assert a part of it to avoid flakyness

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
