### PR TITLE
update(test): use regex pattern for version number test

### DIFF
--- a/playwright/specs/18-settings-about.spec.ts
+++ b/playwright/specs/18-settings-about.spec.ts
@@ -5,7 +5,7 @@ import { SettingsAbout } from "playwright/PageObjects/Settings/SettingsAbout";
 
 test.describe("Settings About Tests", () => {
   const BASE_URL = "https://satellite.im/";
-  const VERSION = "0.2.5";
+  const versionPattern = /^\d+\.\d+\.\d+$/;
   const GITHUB_URL = "https://github.com/Satellite-im";
 
   test.beforeEach(async ({ singleUserContext }) => {
@@ -42,7 +42,8 @@ test.describe("Settings About Tests", () => {
 
     // Label and texts for settings section are correct
     await expect(settingsAbout.versionSectionLabel).toHaveText("Version");
-    await expect(settingsAbout.versionSectionText).toHaveText(VERSION);
+    const versionNumber = await settingsAbout.versionSectionText.textContent();
+    expect(versionNumber).toMatch(versionPattern);
   });
 
   // Cannot be automated now since button does not perform any action


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Use regex to test the version number on Settings About instead of having it hardcoded in tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
